### PR TITLE
Fix bug of schedulers

### DIFF
--- a/celerybeatmongo/schedulers.py
+++ b/celerybeatmongo/schedulers.py
@@ -78,7 +78,10 @@ class MongoScheduleEntry(ScheduleEntry):
         if self.last_run_at and self._task.last_run_at and self.last_run_at > self._task.last_run_at:
             self._task.last_run_at = self.last_run_at
         self._task.run_immediately = False
-        self._task.save()
+        try:
+            self._task.save(save_condition={})
+        except Exception:
+            get_logger(__name__).error(traceback.format_exc())
 
 
 class MongoScheduler(Scheduler):


### PR DESCRIPTION
The save method of mongoengine.DynamicDocument has a parameters named
save_condition. If save_condition is None, the `upsert` will be set to
True. And this will generate a new record while try to update a not
exist record.

The save method of class `MongoScheduleEntry` try to save `PeriodicTask`
entry. However, if the record has been remove before the entry saved,
the PeriodicTask.save method will generate a new record like:
{"_id": Object("585ccddda098134e9bb94224"), "total_run_count": 1, "last_run_at": ISODate("2016-12-23T15:10:21.709Z")}

This will make program crash with execution: duplicate key error collection