### PR TITLE
Don't throw error if task has been deleted

### DIFF
--- a/celerybeatmongo/schedulers.py
+++ b/celerybeatmongo/schedulers.py
@@ -89,7 +89,8 @@ class MongoScheduleEntry(ScheduleEntry):
             self._task.save(save_condition={})
         except Exception:
             get_logger(__name__).error(traceback.format_exc())
-
+        except mongoengine.errors.NotUniqueError:
+            pass
 
 class MongoScheduler(Scheduler):
 
@@ -149,4 +150,7 @@ class MongoScheduler(Scheduler):
 
     def sync(self):
         for entry in self._schedule.values():
-            entry.save()
+            try:
+                entry.save()
+            except mongoengine.errors.NotUniqueError:
+                pass


### PR DESCRIPTION
Hi,

I can't disable a task after creating it. Celery still is still executing it after.
So I wrote a small bug fix but it is not very pretty.