### PR TITLE
Make stored entries sensible to 'enabled' field.

### DIFF
--- a/celerybeatmongo/schedulers.py
+++ b/celerybeatmongo/schedulers.py
@@ -32,7 +32,8 @@ class MongoScheduleEntry(ScheduleEntry):
             'exchange': self._task.exchange,
             'routing_key': self._task.routing_key,
             'expires': self._task.expires,
-            'soft_time_limit': self._task.soft_time_limit
+            'soft_time_limit': self._task.soft_time_limit,
+            'enabled': self._task.enabled
         }
         if self._task.total_run_count is None:
             self._task.total_run_count = 0


### PR DESCRIPTION
Put task's 'enabled' field into MongoScheduleEntry's options so that the task will be reloaded if 'enabled' is changed.
This fixes issue 'Task enabled #34.'