### PR TITLE
Added connection alias and fixed current way of getting current_app.conf

### DIFF
--- a/celerybeatmongo/models.py
+++ b/celerybeatmongo/models.py
@@ -11,14 +11,10 @@ import celery.schedules
 
 
 def get_periodic_task_collection():
-    if hasattr(current_app.conf, "mongodb_scheduler_collection") \
-        or hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_COLLECTION"):
-        try:
-            collections = current_app.conf.get("mongodb_scheduler_collection")
-        except:
-            collections = current_app.conf.CELERY_MONGODB_SCHEDULER_COLLECTION
-        if collections:
-            return collections
+    if hasattr(current_app.conf, "mongodb_scheduler_collection"):
+        return current_app.conf.get("mongodb_scheduler_collection")
+    elif hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_COLLECTION"):
+        return current_app.conf.CELERY_MONGODB_SCHEDULER_COLLECTION
     return "schedules"
 
 

--- a/celerybeatmongo/models.py
+++ b/celerybeatmongo/models.py
@@ -12,8 +12,13 @@ import celery.schedules
 
 def get_periodic_task_collection():
     if hasattr(current_app.conf, "mongodb_scheduler_collection") \
-            and current_app.conf.get("mongodb_scheduler_collection"):
-        return current_app.conf.get("mongodb_scheduler_collection")
+        or hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_COLLECTION"):
+        try:
+            collections = current_app.conf.get("mongodb_scheduler_collection")
+        except:
+            collections = current_app.conf.CELERY_MONGODB_SCHEDULER_COLLECTION
+        if collections:
+            return collections
     return "schedules"
 
 

--- a/celerybeatmongo/models.py
+++ b/celerybeatmongo/models.py
@@ -11,9 +11,9 @@ import celery.schedules
 
 
 def get_periodic_task_collection():
-    if hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_COLLECTION") \
-            and current_app.conf.CELERY_MONGODB_SCHEDULER_COLLECTION:
-        return current_app.conf.CELERY_MONGODB_SCHEDULER_COLLECTION
+    if hasattr(current_app.conf, "mongodb_scheduler_collection") \
+            and current_app.conf.get("mongodb_scheduler_collection"):
+        return current_app.conf.get("mongodb_scheduler_collection")
     return "schedules"
 
 

--- a/celerybeatmongo/schedulers.py
+++ b/celerybeatmongo/schedulers.py
@@ -103,20 +103,31 @@ class MongoScheduler(Scheduler):
     Model = PeriodicTask
 
     def __init__(self, *args, **kwargs):
-        import pdb; pdb.set_trace()
-        if hasattr(current_app.conf, "mongodb_scheduler_db"):
-            db = current_app.conf.get("mongodb_scheduler_db")
+        if hasattr(current_app.conf, "mongodb_scheduler_db") \
+            or hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_DB"):
+            try:
+                db = current_app.conf.get("mongodb_scheduler_db")
+            except:
+                db = current_app.conf.CELERY_MONGODB_SCHEDULER_DB
         else:
             db = "celery"
-        if hasattr(current_app.conf, "mongodb_scheduler_connection_alias"):
-            alias = current_app.conf.get('mongodb_scheduler_connection_alias')
+        if hasattr(current_app.conf, "mongodb_scheduler_connection_alias") \
+            or hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_CONNECTION_ALIAS"):
+            try:
+                alias = current_app.conf.get('mongodb_scheduler_connection_alias')
+            except:
+                alias = current_app.conf.CELERY_MONGODB_SCHEDULER_CONNECTION_ALIAS
         else:
             alias = "default"
-        if hasattr(current_app.conf, "mongodb_scheduler_url"):
-            self._mongo = mongoengine.connect(db, host=current_app.conf.get("mongodb_scheduler_url"), alias=alias)
+        if hasattr(current_app.conf, "mongodb_scheduler_url") \
+            or hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_URL"):
+            try:
+                host = current_app.conf.get('mongodb_scheduler_url')
+            except:
+                host = current_app.conf.CELERY_MONGODB_SCHEDULER_URL
+            self._mongo = mongoengine.connect(db, host=host, alias=alias)
             get_logger(__name__).info("backend scheduler using %s/%s:%s",
-                    current_app.conf.get("mongodb_scheduler_url"),
-                    db, self.Model._get_collection().name)
+                    host, db, self.Model._get_collection().name)
         else:
             self._mongo = mongoengine.connect(db, alias=alias)
             get_logger(__name__).info("backend scheduler using %s/%s:%s",

--- a/celerybeatmongo/schedulers.py
+++ b/celerybeatmongo/schedulers.py
@@ -103,33 +103,33 @@ class MongoScheduler(Scheduler):
     Model = PeriodicTask
 
     def __init__(self, *args, **kwargs):
-        if hasattr(current_app.conf, "mongodb_scheduler_db") \
-            or hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_DB"):
-            try:
-                db = current_app.conf.get("mongodb_scheduler_db")
-            except:
-                db = current_app.conf.CELERY_MONGODB_SCHEDULER_DB
+        if hasattr(current_app.conf, "mongodb_scheduler_db"):
+            db = current_app.conf.get("mongodb_scheduler_db")
+        elif hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_DB"):
+            db = current_app.conf.CELERY_MONGODB_SCHEDULER_DB
         else:
             db = "celery"
-        if hasattr(current_app.conf, "mongodb_scheduler_connection_alias") \
-            or hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_CONNECTION_ALIAS"):
-            try:
-                alias = current_app.conf.get('mongodb_scheduler_connection_alias')
-            except:
-                alias = current_app.conf.CELERY_MONGODB_SCHEDULER_CONNECTION_ALIAS
+
+        if hasattr(current_app.conf, "mongodb_scheduler_connection_alias"):
+            alias = current_app.conf.get('mongodb_scheduler_connection_alias')
+        elif hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_CONNECTION_ALIAS"):
+            alias = current_app.conf.CELERY_MONGODB_SCHEDULER_CONNECTION_ALIAS
         else:
             alias = "default"
-        if hasattr(current_app.conf, "mongodb_scheduler_url") \
-            or hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_URL"):
-            try:
-                host = current_app.conf.get('mongodb_scheduler_url')
-            except:
-                host = current_app.conf.CELERY_MONGODB_SCHEDULER_URL
-            self._mongo = mongoengine.connect(db, host=host, alias=alias)
+
+        if hasattr(current_app.conf, "mongodb_scheduler_url"):
+            host = current_app.conf.get('mongodb_scheduler_url')
+        elif hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_URL"):
+            host = current_app.conf.CELERY_MONGODB_SCHEDULER_URL
+        else:
+            host = None
+
+        self._mongo = mongoengine.connect(db, host=host, alias=alias)
+
+        if host:
             get_logger(__name__).info("backend scheduler using %s/%s:%s",
                     host, db, self.Model._get_collection().name)
         else:
-            self._mongo = mongoengine.connect(db, alias=alias)
             get_logger(__name__).info("backend scheduler using %s/%s:%s",
                     "mongodb://localhost",
                     db, self.Model._get_collection().name)

--- a/celerybeatmongo/schedulers.py
+++ b/celerybeatmongo/schedulers.py
@@ -103,17 +103,22 @@ class MongoScheduler(Scheduler):
     Model = PeriodicTask
 
     def __init__(self, *args, **kwargs):
-        if hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_DB"):
-            db = current_app.conf.CELERY_MONGODB_SCHEDULER_DB
+        import pdb; pdb.set_trace()
+        if hasattr(current_app.conf, "mongodb_scheduler_db"):
+            db = current_app.conf.get("mongodb_scheduler_db")
         else:
             db = "celery"
-        if hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_URL"):
-            self._mongo = mongoengine.connect(db, host=current_app.conf.CELERY_MONGODB_SCHEDULER_URL)
+        if hasattr(current_app.conf, "mongodb_scheduler_connection_alias"):
+            alias = current_app.conf.get('mongodb_scheduler_connection_alias')
+        else:
+            alias = "default"
+        if hasattr(current_app.conf, "mongodb_scheduler_url"):
+            self._mongo = mongoengine.connect(db, host=current_app.conf.get("mongodb_scheduler_url"), alias=alias)
             get_logger(__name__).info("backend scheduler using %s/%s:%s",
-                    current_app.conf.CELERY_MONGODB_SCHEDULER_URL,
+                    current_app.conf.get("mongodb_scheduler_url"),
                     db, self.Model._get_collection().name)
         else:
-            self._mongo = mongoengine.connect(db)
+            self._mongo = mongoengine.connect(db, alias=alias)
             get_logger(__name__).info("backend scheduler using %s/%s:%s",
                     "mongodb://localhost",
                     db, self.Model._get_collection().name)


### PR DESCRIPTION
I added a way to specify a connection alias in order to prevent a mongo engine exceptionwhen trying to handle multiple mongodb connections.
I also fixed the current way of checking the existence of and getting attributes in current_app.conf. The current way mays have worked in the past but now the celery app configuration is in full lowercase, therefore the if statements were never triggered when I tested it.