### PR TITLE
Interval and Crontab models as separated class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .*
 *.egg-info
 /env
+/build/

--- a/Changelog
+++ b/Changelog
@@ -1,0 +1,11 @@
+.. _changelog:
+
+================
+ Change history
+================
+
+0.2.1
+=====
+
+- Makes PeriodicTask.name as required field
+- Fix enabled tasks do not run when there is another schedule entry which is disabled (#37)

--- a/README.rst
+++ b/README.rst
@@ -36,19 +36,19 @@ create the interval object::
     from celery import Celery
 
     config = {
-        "mongodb_scheduler_db": "test_stormy",
+        "mongodb_scheduler_db": "my_project",
         "mongodb_scheduler_url": "mongodb://localhost:27017",
     }
 
     app = Celery('hello', broker='redis://localhost//')
     app.conf.update(**config)
 
-    from celerybeatmongo.models import PeriodicTask
+    from celerybeatmongo.models import PeriodicTask, Interval
 
     periodic = PeriodicTask(
         name='Importing contacts',
         task="proj.import_contacts"
-        interval=PeriodicTask.Interval(every=10, period="seconds") # executes every 10 seconds.
+        interval=Interval(every=10, period="seconds") # executes every 10 seconds.
     )
     periodic.save()
 
@@ -66,19 +66,16 @@ A crontab schedule has the fields: minute, hour, day_of_week, day_of_month and m
     from celery import Celery
 
     config = {
-        "mongodb_scheduler_db": "test_stormy",
+        "mongodb_scheduler_db": "my_project",
         "mongodb_scheduler_url": "mongodb://localhost:27017",
     }
 
     app = Celery('hello', broker='redis://localhost//')
     app.conf.update(**config)
 
-    from celerybeatmongo.models import PeriodicTask
+    from celerybeatmongo.models import PeriodicTask, Crontab
 
     periodic = PeriodicTask(name="Send Email Notification", task="proj.notify_customers")
-    periodic.crontab = PeriodicTask.Crontab(minute="30",
-                                            hour="7",
-                                            day_of_week="1",
-                                            day_of_month="0",
-                                            month_of_year="*")
+    periodic.crontab = Crontab(minute="30", hour="7", day_of_week="1",
+                               day_of_month="0", month_of_year="*")
     periodic.save()

--- a/README.rst
+++ b/README.rst
@@ -12,128 +12,73 @@ And specifying the scheduler when running Celery Beat, e.g.::
 
     $ celery beat -S celerybeatmongo.schedulers.MongoScheduler
 
-Settings for the scheduler are defined in your celery configuration file
-similar to how other aspects of Celery are configured::
+Settings
+########
 
-    CELERY_MONGODB_SCHEDULER_DB = "celery"
-    CELERY_MONGODB_SCHEDULER_COLLECTION = "schedules"
-    CELERY_MONGODB_SCHEDULER_URL = "mongodb://userid:password@hostname:port"
+The settings for the scheduler are defined in your celery configuration file
+similar to how other aspects of Celery are configured:
 
-If no settings are specified, the library will attempt to use the
-**schedules** collection in the local **celery** database.
+* mongodb_scheduler_url: The mongodb `url <https://docs.mongodb.com/manual/reference/connection-string/>`_ connection used to store task results.
+* mongodb_scheduler_db: The Mongodb database name
+* mongodb_scheduler_collection (optional): the collection name used by model. If no value are specified, the default value will be used: **schedules**.
 
-Schedules can be manipulated in the Mongo database using the
-mongoengine models in celerybeatmongo.models or through
-direct database manipulation. There exist two types of schedules,
-interval and crontab.
+Usage
+===================
+Celerybeat-mongo just supports Interval and Crontab schedules.
+Schedules easily can be manipulated using the mongoengine models in celerybeat mongo.models module.
 
-**IMPORTANT**: because Mongoengine (http://mongoengine-odm.readthedocs.org/) is used to read 
-	the database, objects must have a field `_cls` set to `PeriodicTask`.  Why?  Because 
-	Mongoengine allows Document Inheritance (by default: on), which automatically adds extra 
-	fields indices (**_cls**) 
-	(http://docs.mongoengine.org/guide/defining-documents.html?highlight=Document%20Inheritance).
-	
+Example creating interval-based periodic task
+---------------------------------------------
 
-Interval::
+To create a periodic task executing at an interval you must first
+create the interval object::
 
-    {
-        "_id" : ObjectId("533c5b29b45a2092bffceb13"),
-        "_cls": "PeriodicTask",
-        "name" : "interval test schedule",
-        "task" : "task-name-goes-here",
-        "enabled" : true,
-        "interval" : {
-            "every" : 5,
-            "period" : "minutes"
-        },
-        "args" : [
-            "param1",
-            "param2"
-        ],
-        "kwargs" : {
-            "max_targets" : 100
-        },
-        "total_run_count" : 5,
-        "last_run_at" : ISODate("2014-04-03T19:19:22.666+17:00")
+    from celery import Celery
+
+    config = {
+        "mongodb_scheduler_db": "test_stormy",
+        "mongodb_scheduler_url": "mongodb://localhost:27017",
     }
 
-The example from Celery User Guide::Periodic Tasks. ::
+    app = Celery('hello', broker='redis://localhost//')
+    app.conf.update(**config)
 
-    {
-    	CELERYBEAT_SCHEDULE = {
-    	    'add-every-30-seconds': {
-    	        'task': 'tasks.add',
-    	        'schedule': timedelta(seconds=30),
-    	        'args': (16, 16)
-    	    },
-    	}
+    from celerybeatmongo.models import PeriodicTask
+
+    periodic = PeriodicTask(
+        name='Importing contacts',
+        task="proj.import_contacts"
+        interval=PeriodicTask.Interval(every=10, period="seconds") # executes every 10 seconds.
+    )
+    periodic.save()
+
+.. note::
+
+    You should import celerybeat-mongo just after celery initialization.
+
+
+Example creating crontab periodic task
+---------------------------------------------
+
+A crontab schedule has the fields: minute, hour, day_of_week, day_of_month and month_of_year, so if you want the equivalent of a 30 7 * * 1 (Executes every Monday morning at 7:30 a.m) crontab entry you specify::
+
+
+    from celery import Celery
+
+    config = {
+        "mongodb_scheduler_db": "test_stormy",
+        "mongodb_scheduler_url": "mongodb://localhost:27017",
     }
 
-Becomes the following::
+    app = Celery('hello', broker='redis://localhost//')
+    app.conf.update(**config)
 
-    {
-        "_id" : ObjectId("53a91dfd455d1c1a4345fb59"),
-        "_cls": "PeriodicTask",
-        "name" : "crontab test schedule",
-        "task" : "task-name-goes-here",
-        "enabled" : true,
-        "crontab" : {
-            "minute" : "30",
-            "hour" : "2",
-            "day_of_week" : "*",
-            "day_of_month" : "*",
-            "month_of_year" : "*"
-        },
-        "args" : [
-            "param1",
-            "param2"
-        ],
-        "kwargs" : {
-            "max_targets" : 100
-        },
-        "total_run_count" : 5,
-        "last_run_at" : ISODate("2014-04-03T19:19:22.666+17:00")
-    }
+    from celerybeatmongo.models import PeriodicTask
 
-The following fields are required: name, task, crontab || interval,
-enabled when defining new tasks.
-total_run_count and last_run_at are maintained by the
-scheduler and should not be externally manipulated.
-
-The example from Celery User Guide::Periodic Tasks. 
-(see: http://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html#crontab-schedules)::
-
-	{
-		CELERYBEAT_SCHEDULE = {
-		    # Executes every Monday morning at 7:30 A.M
-		    'add-every-monday-morning': {
-		        'task': 'tasks.add',
-		        'schedule': crontab(hour=7, minute=30, day_of_week=1),
-		        'args': (16, 16),
-		    },
-		}
-	}
-
-Becomes::
-
-	{
-	    "_id" : ObjectId("53a91dfd455d1c1a4345fb59"),
-	    "_cls": "PeriodicTask",
-	    "name" : "add-every-monday-morning",
-	    "task" : "tasks.add",
-	    "enabled" : true,
-	    "crontab" : {
-	        "minute" : "30",
-	        "hour" : "7",
-	        "day_of_week" : "1",
-	        "day_of_month" : "*",
-	        "month_of_year" : "*"
-	    },
-	    "args" : [ 
-	        "16", 
-	        "16"
-	    ],
-	    "kwargs" : {},
-	    "total_run_count" : 1,
-	    "last_run_at" : ISODate("2014-06-16T07:30:00.752-07:00")
-	}
+    periodic = PeriodicTask(name="Send Email Notification", task="proj.notify_customers")
+    periodic.crontab = PeriodicTask.Crontab(minute="30",
+                                            hour="7",
+                                            day_of_week="1",
+                                            day_of_month="0",
+                                            month_of_year="*")
+    periodic.save()

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,12 @@
 celerybeat-mongo
 ################
 
-This is a Celery Beat Scheduler (http://celery.readthedocs.org/en/latest/userguide/periodic-tasks.html)
+This is a `Celery Beat Scheduler <http://celery.readthedocs.org/en/latest/userguide/periodic-tasks.html/>`_
 that stores both the schedules themselves and their status
-information in a backend Mongo database. It can be installed by 
+information in a backend Mongo database. It can be installed by
 installing the celerybeat-mongo Python egg::
 
-    # pip install celerybeat-mongo 
+    # pip install celerybeat-mongo
 
 And specifying the scheduler when running Celery Beat, e.g.::
 

--- a/celerybeatmongo/__init__.py
+++ b/celerybeatmongo/__init__.py
@@ -1,0 +1,38 @@
+
+from celery import current_app
+from mongoengine import connect
+from celery.utils.log import get_logger
+
+logger = get_logger(__name__)
+
+COLLECTION_NAME = None
+
+if hasattr(current_app.conf, "mongodb_scheduler_collection"):
+    COLLECTION_NAME = current_app.conf.get("mongodb_scheduler_collection")
+elif hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_COLLECTION"):
+    COLLECTION_NAME = current_app.conf.get("CELERY_MONGODB_SCHEDULER_COLLECTION")
+if not COLLECTION_NAME:
+    COLLECTION_NAME = "schedules"
+
+if hasattr(current_app.conf, "mongodb_scheduler_db"):
+    db = current_app.conf.get("mongodb_scheduler_db")
+elif hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_DB"):
+    db = current_app.conf.CELERY_MONGODB_SCHEDULER_DB
+else:
+    db = "celery"
+
+if hasattr(current_app.conf, "mongodb_scheduler_connection_alias"):
+    alias = current_app.conf.get('mongodb_scheduler_connection_alias')
+elif hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_CONNECTION_ALIAS"):
+    alias = current_app.conf.CELERY_MONGODB_SCHEDULER_CONNECTION_ALIAS
+else:
+    alias = "default"
+
+if hasattr(current_app.conf, "mongodb_scheduler_url"):
+    host = current_app.conf.get('mongodb_scheduler_url')
+elif hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_URL"):
+    host = current_app.conf.CELERY_MONGODB_SCHEDULER_URL
+else:
+    host = None
+
+connection = connect(db, host=host, alias=alias)

--- a/celerybeatmongo/models.py
+++ b/celerybeatmongo/models.py
@@ -73,7 +73,7 @@ class PeriodicTask(DynamicDocument):
                 rfield(self.day_of_month), rfield(self.month_of_year),
             )
 
-    name = StringField(unique=True)
+    name = StringField(required=True, unique=True)
     task = StringField(required=True)
 
     interval = EmbeddedDocumentField(Interval)

--- a/celerybeatmongo/models.py
+++ b/celerybeatmongo/models.py
@@ -6,17 +6,9 @@
 
 import datetime
 from mongoengine import *
-from celery import current_app
 import celery.schedules
 
-
-def get_periodic_task_collection():
-    if hasattr(current_app.conf, "mongodb_scheduler_collection"):
-        return current_app.conf.get("mongodb_scheduler_collection")
-    elif hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_COLLECTION"):
-        return current_app.conf.CELERY_MONGODB_SCHEDULER_COLLECTION
-    return "schedules"
-
+from . import COLLECTION_NAME
 
 #: Authorized values for PeriodicTask.Interval.period
 PERIODS = ('days', 'hours', 'minutes', 'seconds', 'microseconds')
@@ -25,7 +17,7 @@ PERIODS = ('days', 'hours', 'minutes', 'seconds', 'microseconds')
 class PeriodicTask(DynamicDocument):
     """MongoDB model that represents a periodic task"""
 
-    meta = {'collection': get_periodic_task_collection(),
+    meta = {'collection': COLLECTION_NAME,
             'allow_inheritance': True}
 
     class Interval(EmbeddedDocument):

--- a/celerybeatmongo/schedulers.py
+++ b/celerybeatmongo/schedulers.py
@@ -166,5 +166,6 @@ class MongoScheduler(Scheduler):
         return self._schedule
 
     def sync(self):
+        logger.info('Writing entries...')
         for entry in self._schedule.values():
             entry.save()

--- a/celerybeatmongo/schedulers.py
+++ b/celerybeatmongo/schedulers.py
@@ -4,7 +4,6 @@
 # use this file except in compliance with the License. You may obtain a copy
 # of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-import mongoengine
 import traceback
 import datetime
 
@@ -106,35 +105,6 @@ class MongoScheduler(Scheduler):
     Model = PeriodicTask
 
     def __init__(self, *args, **kwargs):
-        if hasattr(current_app.conf, "mongodb_scheduler_db"):
-            db = current_app.conf.get("mongodb_scheduler_db")
-        elif hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_DB"):
-            db = current_app.conf.CELERY_MONGODB_SCHEDULER_DB
-        else:
-            db = "celery"
-
-        if hasattr(current_app.conf, "mongodb_scheduler_connection_alias"):
-            alias = current_app.conf.get('mongodb_scheduler_connection_alias')
-        elif hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_CONNECTION_ALIAS"):
-            alias = current_app.conf.CELERY_MONGODB_SCHEDULER_CONNECTION_ALIAS
-        else:
-            alias = "default"
-
-        if hasattr(current_app.conf, "mongodb_scheduler_url"):
-            host = current_app.conf.get('mongodb_scheduler_url')
-        elif hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_URL"):
-            host = current_app.conf.CELERY_MONGODB_SCHEDULER_URL
-        else:
-            host = None
-
-        self._mongo = mongoengine.connect(db, host=host, alias=alias)
-
-        if host:
-            logger.info("backend scheduler using %s/%s:%s",
-                        host, db, self.Model._get_collection().name)
-        else:
-            logger.info("backend scheduler using %s/%s:%s",
-                        "mongodb://localhost", db, self.Model._get_collection().name)
         self._schedule = {}
         self._last_updated = None
         Scheduler.__init__(self, *args, **kwargs)

--- a/celerybeatmongo/schedulers.py
+++ b/celerybeatmongo/schedulers.py
@@ -121,7 +121,7 @@ class MongoScheduler(Scheduler):
             return True
         return self._last_updated + self.UPDATE_INTERVAL < datetime.datetime.now()
 
-    def all_as_schedule(self):
+    def get_from_database(self):
         self.sync()
         scheds = {}
         for pt in self.Model.objects.filter(enabled=True):
@@ -131,7 +131,7 @@ class MongoScheduler(Scheduler):
     @property
     def schedule(self):
         if self.requires_update():
-            self._schedule = self.all_as_schedule()
+            self._schedule = self.get_from_database()
             self._last_updated = datetime.datetime.now()
         return self._schedule
 

--- a/celerybeatmongo/schedulers.py
+++ b/celerybeatmongo/schedulers.py
@@ -121,17 +121,17 @@ class MongoScheduler(Scheduler):
             return True
         return self._last_updated + self.UPDATE_INTERVAL < datetime.datetime.now()
 
-    def get_from_database(self):
+    def all_as_schedule(self):
         self.sync()
-        d = {}
-        for doc in self.Model.objects():
-            d[doc.name] = self.Entry(doc)
-        return d
+        scheds = {}
+        for pt in self.Model.objects.filter(enabled=True):
+            scheds[pt.name] = self.Entry(pt)
+        return scheds
 
     @property
     def schedule(self):
         if self.requires_update():
-            self._schedule = self.get_from_database()
+            self._schedule = self.all_as_schedule()
             self._last_updated = datetime.datetime.now()
         return self._schedule
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+celery
+mongoengine
+pymongo

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,6 +7,7 @@ class BeatMongoCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        disconnect()
         connect('mongoenginetest', host='mongomock://localhost')
 
     @classmethod

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,0 +1,89 @@
+
+import random
+import unittest
+import importlib
+
+from celery import Celery
+from mongoengine import disconnect
+
+
+class ConfigTest(unittest.TestCase):
+
+    def setUp(self):
+        self.app = Celery()
+        disconnect()
+
+    def tearDown(self):
+        disconnect()
+
+    def test_collection_name(self):
+        config_old = {"CELERY_MONGODB_SCHEDULER_COLLECTION": "REC" + str(random.randint(10, 1000))}
+        self.app.conf.update(**config_old)
+        import celerybeatmongo
+        importlib.reload(celerybeatmongo)
+        self.assertEqual(celerybeatmongo.COLLECTION_NAME, config_old["CELERY_MONGODB_SCHEDULER_COLLECTION"])
+
+        config_new = {"mongodb_scheduler_collection": "BAC" + str(random.randint(10, 1000))}
+        self.app.conf.update(**config_new)
+        importlib.reload(celerybeatmongo)
+        self.assertEqual(celerybeatmongo.COLLECTION_NAME, config_new["mongodb_scheduler_collection"])
+
+        self.app = Celery()
+        importlib.reload(celerybeatmongo)
+        self.assertEqual("schedules", celerybeatmongo.COLLECTION_NAME,
+                         "The default value for scheduler collection is 'schedules'")
+
+    def test_db_name(self):
+        config_old = {"CELERY_MONGODB_SCHEDULER_DB": "DB" + str(random.randint(10, 1000))}
+        self.app.conf.update(**config_old)
+        import celerybeatmongo
+        importlib.reload(celerybeatmongo)
+        disconnect()
+        self.assertEqual(celerybeatmongo.db, config_old["CELERY_MONGODB_SCHEDULER_DB"])
+
+        config_new = {"mongodb_scheduler_db": "db" + str(random.randint(10, 1000))}
+        self.app.conf.update(**config_new)
+        importlib.reload(celerybeatmongo)
+        disconnect()
+        self.assertEqual(celerybeatmongo.db, config_new["mongodb_scheduler_db"])
+
+        self.app = Celery()
+        importlib.reload(celerybeatmongo)
+        self.assertEqual("celery", celerybeatmongo.db, "The default value db name is 'celery'")
+
+    def test_connection_alias(self):
+        config_old = {"CELERY_MONGODB_SCHEDULER_CONNECTION_ALIAS": "ALIAS" + str(random.randint(10, 1000))}
+        self.app.conf.update(**config_old)
+        import celerybeatmongo
+        importlib.reload(celerybeatmongo)
+        disconnect()
+        self.assertEqual(celerybeatmongo.alias, config_old["CELERY_MONGODB_SCHEDULER_CONNECTION_ALIAS"])
+
+        config_new = {"mongodb_scheduler_connection_alias": "alias" + str(random.randint(10, 1000))}
+        self.app.conf.update(**config_new)
+        importlib.reload(celerybeatmongo)
+        disconnect()
+        self.assertEqual(celerybeatmongo.alias, config_new["mongodb_scheduler_connection_alias"])
+
+        self.app = Celery()
+        importlib.reload(celerybeatmongo)
+        disconnect()
+        self.assertEqual("default", celerybeatmongo.alias, "The default connection alias is 'default'")
+
+    def test_connection_host(self):
+        config_old = {"CELERY_MONGODB_SCHEDULER_URL": "ALIAS" + str(random.randint(10, 1000))}
+        self.app.conf.update(**config_old)
+        import celerybeatmongo
+        importlib.reload(celerybeatmongo)
+        disconnect()
+        self.assertEqual(celerybeatmongo.host, config_old["CELERY_MONGODB_SCHEDULER_URL"])
+
+        config_new = {"mongodb_scheduler_url": "alias" + str(random.randint(10, 1000))}
+        self.app.conf.update(**config_new)
+        importlib.reload(celerybeatmongo)
+        disconnect()
+        self.assertEqual(celerybeatmongo.host, config_new["mongodb_scheduler_url"])
+
+        self.app = Celery()
+        importlib.reload(celerybeatmongo)
+        self.assertIsNone(celerybeatmongo.host)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,8 @@
 
+import importlib
 import unittest
 from mongoengine import ValidationError
+from celery import Celery
 
 from celerybeatmongo.models import PeriodicTask
 from tests import BeatMongoCase
@@ -54,3 +56,12 @@ class PeriodicTaskTest(unittest.TestCase):
         with self.assertRaises(ValidationError) as err:
             periodic.save()
         self.assertTrue("Cannot define both interval and crontab schedule." in err.exception.message)
+
+    def test_collection_name(self):
+        app = Celery()
+        app.conf.update(**{"mongodb_scheduler_collection": "schedules2"})
+        import celerybeatmongo
+        importlib.reload(celerybeatmongo)
+        importlib.reload(celerybeatmongo.models)
+        from celerybeatmongo.models import PeriodicTask
+        self.assertEqual("schedules2", PeriodicTask._get_collection().name)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,13 +17,13 @@ class IntervalScheduleTest(BeatMongoCase):
             periodic.save()
 
     def test_scheduler(self):
-        periodic = PeriodicTask(task="foo")
+        periodic = PeriodicTask(name="my task", task="foo")
         periodic.interval = PeriodicTask.Interval(every=1, period="days")
         periodic.save()
         self.assertIsNotNone(periodic.schedule)
 
     def test_str(self):
-        periodic = PeriodicTask(task="foo")
+        periodic = PeriodicTask(name="my task", task="foo")
         periodic.interval = PeriodicTask.Interval(every=1, period="days")
         self.assertEqual("every day", str(periodic.interval))
 
@@ -34,7 +34,7 @@ class IntervalScheduleTest(BeatMongoCase):
 class CrontabScheduleTest(unittest.TestCase):
 
     def test_str(self):
-        periodic = PeriodicTask(task="foo")
+        periodic = PeriodicTask(name="my task", task="foo")
         periodic.crontab = PeriodicTask.Crontab(minute="0", hour="*", day_of_week="*",
                                                 day_of_month="10-15", month_of_year="*")
         self.assertEqual("0 * * 10-15 * (m/h/d/dM/MY)", str(periodic.crontab))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,10 +1,14 @@
 
 import importlib
 import unittest
+
 from mongoengine import ValidationError
 from celery import Celery
 
 from celerybeatmongo.models import PeriodicTask
+from celerybeatmongo.models import Interval
+from celerybeatmongo.models import Crontab
+
 from tests import BeatMongoCase
 
 
@@ -13,31 +17,57 @@ class IntervalScheduleTest(BeatMongoCase):
     def test_cannot_save_interval_schduler_with_a_invalid_period(self):
         periodic = PeriodicTask(task="foo")
         with self.assertRaises(ValidationError):
-            periodic.interval = PeriodicTask.Interval(every=1, period="days111")
+            periodic.interval = Interval(every=1, period="days111")
             periodic.save()
 
     def test_scheduler(self):
         periodic = PeriodicTask(name="my task", task="foo")
-        periodic.interval = PeriodicTask.Interval(every=1, period="days")
+        periodic.interval = Interval(every=1, period="days")
         periodic.save()
         self.assertIsNotNone(periodic.schedule)
 
     def test_str(self):
         periodic = PeriodicTask(name="my task", task="foo")
-        periodic.interval = PeriodicTask.Interval(every=1, period="days")
+        periodic.interval = Interval(every=1, period=Interval.DAYS)
         self.assertEqual("every day", str(periodic.interval))
 
-        periodic.interval = PeriodicTask.Interval(every=2, period="days")
+        periodic.interval = Interval(every=2, period=Interval.DAYS)
         self.assertEqual('every 2 days', str(periodic.interval))
 
+    def test_model_inner_class_compatibility(self):
+        task1 = PeriodicTask(name="Task A",
+                             task="proj.foo",
+                             interval=Interval(every=1, period=Interval.HOURS))
+        task1.save()
 
-class CrontabScheduleTest(unittest.TestCase):
+        task2 = PeriodicTask(name="Task B",
+                             task="proj.foo",
+                             interval=PeriodicTask.Interval(every=1, period=Interval.HOURS))
+        task2.save()
+        self.assertEqual(task1.to_mongo()['interval'], task2.to_mongo()['interval'])
+
+
+class CrontabScheduleTest(BeatMongoCase):
 
     def test_str(self):
         periodic = PeriodicTask(name="my task", task="foo")
-        periodic.crontab = PeriodicTask.Crontab(minute="0", hour="*", day_of_week="*",
-                                                day_of_month="10-15", month_of_year="*")
+        periodic.crontab = Crontab(minute="0", hour="*", day_of_week="*",
+                                   day_of_month="10-15", month_of_year="*")
         self.assertEqual("0 * * 10-15 * (m/h/d/dM/MY)", str(periodic.crontab))
+
+    def test_model_inner_class_compatibility(self):
+        task1 = PeriodicTask(name="Task A",
+                             task="proj.foo",
+                             crontab=Crontab(minute="0", hour="*", day_of_week="*",
+                                             day_of_month="10-15", month_of_year="*"))
+        task1.save()
+
+        task2 = PeriodicTask(name="Task B",
+                             task="proj.foo",
+                             crontab=PeriodicTask.Crontab(minute="0", hour="*", day_of_week="*",
+                                                          day_of_month="10-15", month_of_year="*"))
+        task2.save()
+        self.assertEqual(task1.to_mongo()['crontab'], task2.to_mongo()['crontab'])
 
 
 class PeriodicTaskTest(unittest.TestCase):
@@ -50,9 +80,9 @@ class PeriodicTaskTest(unittest.TestCase):
 
     def test_cannot_define_both_interval_and_contrab(self):
         periodic = PeriodicTask(task="foo")
-        periodic.interval = PeriodicTask.Interval(every=1, period="days")
-        periodic.crontab = PeriodicTask.Crontab(minute="0", hour="*", day_of_week="*",
-                                                day_of_month="10-15", month_of_year="*")
+        periodic.interval = Interval(every=1, period="days")
+        periodic.crontab = Crontab(minute="0", hour="*", day_of_week="*",
+                                   day_of_month="10-15", month_of_year="*")
         with self.assertRaises(ValidationError) as err:
             periodic.save()
         self.assertTrue("Cannot define both interval and crontab schedule." in err.exception.message)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -18,11 +18,11 @@ class MongoSchedulerTest(unittest.TestCase):
 
     def test_all_as_schedule(self):
         from celerybeatmongo.schedulers import MongoScheduler
-        from celerybeatmongo.models import PeriodicTask
+        from celerybeatmongo.models import PeriodicTask, Interval
         PeriodicTask.drop_collection()
 
-        PeriodicTask.objects.create(name="a1", task="foo", enabled=True, interval=PeriodicTask.Interval(every=1, period="days"))
-        PeriodicTask.objects.create(name="b1", task="foo", enabled=True, interval=PeriodicTask.Interval(every=2, period="days"))
+        PeriodicTask.objects.create(name="a1", task="foo", enabled=True, interval=Interval(every=1, period="days"))
+        PeriodicTask.objects.create(name="b1", task="foo", enabled=True, interval=Interval(every=2, period="days"))
         PeriodicTask.objects.create(name="c2", task="foo", enabled=False, interval=PeriodicTask.Interval(every=3, period="days"))
 
         scheduler = MongoScheduler(app=self.app)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -26,5 +26,5 @@ class MongoSchedulerTest(unittest.TestCase):
         PeriodicTask.objects.create(name="c2", task="foo", enabled=False, interval=PeriodicTask.Interval(every=3, period="days"))
 
         scheduler = MongoScheduler(app=self.app)
-        self.assertEqual(2, len(scheduler.all_as_schedule())
+        self.assertEqual(2, len(scheduler.get_from_database())
                          , "all_as_schedule should return just enabled tasks")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,29 @@
+
+import unittest
+from mongoengine import disconnect_all
+from celery import Celery
+
+
+class MongoSchedulerTest(unittest.TestCase):
+
+    def setUp(self):
+        conf = {
+            "mongodb_scheduler_url": "mongomock://localhost"
+        }
+        self.app = Celery(**conf)
+        self.app.conf.update(**conf)
+
+    def tearDown(self):
+        disconnect_all()
+
+    def test_all_as_schedule(self):
+        from celerybeatmongo.schedulers import MongoScheduler
+        from celerybeatmongo.models import PeriodicTask
+
+        PeriodicTask.objects.create(name="a", task="foo", enabled=True, interval=PeriodicTask.Interval(every=1, period="days"))
+        PeriodicTask.objects.create(name="b", task="foo", enabled=True, interval=PeriodicTask.Interval(every=2, period="days"))
+        PeriodicTask.objects.create(name="c", task="foo", enabled=False, interval=PeriodicTask.Interval(every=3, period="days"))
+
+        scheduler = MongoScheduler(app=self.app)
+        self.assertEqual(2, len(scheduler.all_as_schedule())
+                         , "all_as_schedule should return just enabled tasks")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,6 +1,6 @@
 
 import unittest
-from mongoengine import disconnect_all
+from mongoengine import disconnect
 from celery import Celery
 
 
@@ -14,15 +14,16 @@ class MongoSchedulerTest(unittest.TestCase):
         self.app.conf.update(**conf)
 
     def tearDown(self):
-        disconnect_all()
+        disconnect()
 
     def test_all_as_schedule(self):
         from celerybeatmongo.schedulers import MongoScheduler
         from celerybeatmongo.models import PeriodicTask
+        PeriodicTask.drop_collection()
 
-        PeriodicTask.objects.create(name="a", task="foo", enabled=True, interval=PeriodicTask.Interval(every=1, period="days"))
-        PeriodicTask.objects.create(name="b", task="foo", enabled=True, interval=PeriodicTask.Interval(every=2, period="days"))
-        PeriodicTask.objects.create(name="c", task="foo", enabled=False, interval=PeriodicTask.Interval(every=3, period="days"))
+        PeriodicTask.objects.create(name="a1", task="foo", enabled=True, interval=PeriodicTask.Interval(every=1, period="days"))
+        PeriodicTask.objects.create(name="b1", task="foo", enabled=True, interval=PeriodicTask.Interval(every=2, period="days"))
+        PeriodicTask.objects.create(name="c2", task="foo", enabled=False, interval=PeriodicTask.Interval(every=3, period="days"))
 
         scheduler = MongoScheduler(app=self.app)
         self.assertEqual(2, len(scheduler.all_as_schedule())


### PR DESCRIPTION
[Fix #37] Enabled tasks do not run when there is another schedule entry which is disabled
Changes Interval and Crontab to separated class
Makes PeriodicTask.name as required field
Improves the Readme to work with models instead of pure mongodb collections