### PR TITLE
A better error message for celery app missing on MongoScheduler class instantiation

### DIFF
--- a/celerybeatmongo/schedulers.py
+++ b/celerybeatmongo/schedulers.py
@@ -105,25 +105,24 @@ class MongoScheduler(Scheduler):
 
     Model = PeriodicTask
 
-    def __init__(self, *args, **kwargs):
-        if hasattr(current_app.conf, "mongodb_scheduler_db"):
-            db = current_app.conf.get("mongodb_scheduler_db")
-        elif hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_DB"):
-            db = current_app.conf.CELERY_MONGODB_SCHEDULER_DB
+    def __init__(self, app, *args, **kwargs):
+        if hasattr(app.conf, "mongodb_scheduler_db"):
+            db = app.conf.get("mongodb_scheduler_db")
+        elif hasattr(app.conf, "CELERY_MONGODB_SCHEDULER_DB"):
+            db = app.conf.CELERY_MONGODB_SCHEDULER_DB
         else:
             db = "celery"
-
-        if hasattr(current_app.conf, "mongodb_scheduler_connection_alias"):
-            alias = current_app.conf.get('mongodb_scheduler_connection_alias')
-        elif hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_CONNECTION_ALIAS"):
-            alias = current_app.conf.CELERY_MONGODB_SCHEDULER_CONNECTION_ALIAS
+        if hasattr(app.conf, "mongodb_scheduler_connection_alias"):
+            alias = app.conf.get('mongodb_scheduler_connection_alias')
+        elif hasattr(app.conf, "CELERY_MONGODB_SCHEDULER_CONNECTION_ALIAS"):
+            alias = app.conf.CELERY_MONGODB_SCHEDULER_CONNECTION_ALIAS
         else:
             alias = "default"
 
-        if hasattr(current_app.conf, "mongodb_scheduler_url"):
-            host = current_app.conf.get('mongodb_scheduler_url')
-        elif hasattr(current_app.conf, "CELERY_MONGODB_SCHEDULER_URL"):
-            host = current_app.conf.CELERY_MONGODB_SCHEDULER_URL
+        if hasattr(app.conf, "mongodb_scheduler_url"):
+            host = app.conf.get('mongodb_scheduler_url')
+        elif hasattr(app.conf, "CELERY_MONGODB_SCHEDULER_URL"):
+            host = app.conf.CELERY_MONGODB_SCHEDULER_URL
         else:
             host = None
 
@@ -137,7 +136,7 @@ class MongoScheduler(Scheduler):
                         "mongodb://localhost", db, self.Model._get_collection().name)
         self._schedule = {}
         self._last_updated = None
-        Scheduler.__init__(self, *args, **kwargs)
+        Scheduler.__init__(self, app, *args, **kwargs)
         self.max_interval = (kwargs.get('max_interval')
                              or self.app.conf.CELERYBEAT_MAX_LOOP_INTERVAL or 5)
 

--- a/celerybeatmongo/schedulers.py
+++ b/celerybeatmongo/schedulers.py
@@ -8,6 +8,7 @@ import mongoengine
 import traceback
 import datetime
 
+from celery import schedules
 from celerybeatmongo.models import PeriodicTask
 from celery.beat import Scheduler, ScheduleEntry
 from celery.utils.log import get_logger
@@ -59,13 +60,16 @@ class MongoScheduleEntry(ScheduleEntry):
 
     def is_due(self):
         if not self._task.enabled:
-            return False, 5.0   # 5 second delay for re-enable.
+            return schedules.schedstate(False, 5.0)   # 5 second delay for re-enable.
         if hasattr(self._task, 'start_after') and self._task.start_after:
             if datetime.datetime.now() < self._task.start_after:
-                return False, 5.0
+                return schedules.schedstate(False, 5.0)
         if hasattr(self._task, 'max_run_count') and self._task.max_run_count:
             if (self._task.total_run_count or 0) >= self._task.max_run_count:
-                return False, 5.0
+                self._task.enabled = False
+                self._task.save()
+                # Don't recheck
+                return schedules.schedstate(False, None)
         if self._task.run_immediately:
             # figure out when the schedule would run next anyway
             _, n = self.schedule.is_due(self.last_run_at)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="zakird@gmail.com",
     maintainer="Zakir Durumeric",
     maintainer_email="zakird@gmail.com",
-    keywords="python celery beat mongo",
+    keywords="python celery beat periodic task mongodb",
     packages=[
         "celerybeatmongo"
     ],

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,5 +1,6 @@
 
 import unittest
+
 from mongoengine import disconnect
 from celerybeatmongo.schedulers import MongoScheduler
 from celery import Celery
@@ -8,9 +9,7 @@ from celery import Celery
 class MongoSchedulerTest(unittest.TestCase):
 
     def setUp(self):
-        conf = {
-            "mongodb_scheduler_url": "mongomock://localhost"
-        }
+        conf = {"mongodb_scheduler_url": "mongomock://localhost"}
         self.app = Celery(**conf)
         self.app.conf.update(**conf)
         self.scheduler = MongoScheduler(app=self.app)
@@ -27,3 +26,12 @@ class MongoSchedulerTest(unittest.TestCase):
         scheduler = MongoScheduler(app=self.app)
         self.assertEqual(2, len(scheduler.get_from_database())
                          , "get_from_database should return just enabled tasks")
+
+    def test_max_interval(self):
+        scheduler = MongoScheduler(self.app, max_interval=600, sync_every_tasks=10)
+        self.assertEqual(600, scheduler.max_interval)
+
+    def test_should_create_mongo_db_connection(self):
+        scheduler = MongoScheduler(self.app, max_interval=600, sync_every_tasks=10)
+        self.assertIsNotNone(scheduler._mongo)
+        self.assertEqual(0, scheduler._mongo.db.test.count())


### PR DESCRIPTION
Celery app is already a required parameter for MongoScheduler class.

```python
from celerybeatmongo.schedulers import MongoScheduler
sh = MongoScheduler()
```


This code throws the error: 

`Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/home/reuber/workspace/celerybeat-mongo/celerybeatmongo/schedulers.py", line 139, in __init__`



This PR makes easily to understand that `app` is are required param to instantiate an new MongoScheduler instance.



```python
from celerybeatmongo.schedulers import MongoScheduler
scheduler = MongoScheduler()
```

Now the error is more specific and easily to comprehend: 

Traceback (most recent call last):
  File "<input>", line 1, in <module>
TypeError: __init__() missing 1 required positional argument: 'app'