### PR TITLE
Add the field PeriodicTask.date_created and set date_changed when instance is saved

### DIFF
--- a/celerybeatmongo/models.py
+++ b/celerybeatmongo/models.py
@@ -113,11 +113,15 @@ class PeriodicTask(DynamicDocument):
     run_immediately = BooleanField()
     no_changes = False
 
-    @classmethod
-    def pre_save(cls, sender, document, **kwargs):
-        if not document.date_creation:
-            document.date_creation = datetime.now()
-        document.date_changed = datetime.now()
+    def save(self, force_insert=False, validate=True, clean=True,
+             write_concern=None, cascade=None, cascade_kwargs=None,
+             _refs=None, save_condition=None, signal_kwargs=None, **kwargs):
+        if not self.date_creation:
+            self.date_creation = datetime.now()
+        self.date_changed = datetime.now()
+        super(PeriodicTask, self).save(force_insert, validate, clean,
+                                       write_concern, cascade, cascade_kwargs, _refs,
+                                       save_condition, signal_kwargs, **kwargs)
 
     def clean(self):
         """validation by mongoengine to ensure that you only have
@@ -147,6 +151,3 @@ class PeriodicTask(DynamicDocument):
         else:
             raise Exception("must define interval or crontab schedule")
         return fmt.format(self)
-
-
-signals.pre_save.connect(PeriodicTask.pre_save, sender=PeriodicTask)

--- a/celerybeatmongo/models.py
+++ b/celerybeatmongo/models.py
@@ -4,8 +4,7 @@
 # use this file except in compliance with the License. You may obtain a copy
 # of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-import datetime
-
+from datetime import datetime, timedelta
 from mongoengine import *
 from mongoengine import signals
 
@@ -44,7 +43,7 @@ class PeriodicTask(DynamicDocument):
 
         @property
         def schedule(self):
-            return celery.schedules.schedule(datetime.timedelta(**{self.period: self.every}))
+            return celery.schedules.schedule(timedelta(**{self.period: self.every}))
 
         @property
         def period_singular(self):
@@ -117,7 +116,8 @@ class PeriodicTask(DynamicDocument):
     @classmethod
     def pre_save(cls, sender, document, **kwargs):
         if not document.date_creation:
-            document.date_creation = datetime.datetime.now()
+            document.date_creation = datetime.now()
+        document.date_changed = datetime.now()
 
     def clean(self):
         """validation by mongoengine to ensure that you only have

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 celery
 mongoengine
 pymongo
-blinker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+celery
+mongoengine
+pymongo
+blinker

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         'pymongo',
         'mongoengine',
         'celery',
+        'blinker'
     ],
     classifiers=[
         'Development Status :: 2 - Production/Stable',

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,7 +38,7 @@ class CrontabScheduleTest(unittest.TestCase):
         self.assertEqual("0 * * 10-15 * (m/h/d/dM/MY)", str(periodic.crontab))
 
 
-class PeriodicTaskTest(unittest.TestCase):
+class PeriodicTaskTest(BeatMongoCase):
 
     def test_must_define_interval_or_crontab(self):
         with self.assertRaises(ValidationError) as err:
@@ -54,3 +54,17 @@ class PeriodicTaskTest(unittest.TestCase):
         with self.assertRaises(ValidationError) as err:
             periodic.save()
         self.assertTrue("Cannot define both interval and crontab schedule." in err.exception.message)
+
+    def test_creation_date(self):
+        periodic = PeriodicTask(task="foo")
+        periodic.interval = PeriodicTask.Interval(every=1, period="days")
+        self.assertIsNone(periodic.date_creation,
+                          "date_creation should be none on the first object instantion")
+        periodic.save()
+        self.assertIsNotNone(periodic.date_creation)
+        date_creation = periodic.date_creation
+
+        periodic.name = "I'm changing"
+        periodic.save()
+        self.assertEqual(date_creation, periodic.date_creation,
+                         "Update object should not change date_creation value")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -68,3 +68,16 @@ class PeriodicTaskTest(BeatMongoCase):
         periodic.save()
         self.assertEqual(date_creation, periodic.date_creation,
                          "Update object should not change date_creation value")
+
+    def test_date_changed(self):
+        periodic = PeriodicTask(task="foo")
+        periodic.interval = PeriodicTask.Interval(every=1, period="days")
+
+        self.assertIsNone(periodic.date_changed)
+        periodic.save()
+        self.assertIsNotNone(periodic.date_changed)
+
+        date_changed = periodic.date_changed
+        periodic.name = "I'm changing now"
+        periodic.save()
+        self.assertGreater(periodic.date_changed, date_changed)


### PR DESCRIPTION
This PR add the new field `PeriodicTask.date_created` that is filled automatically on the first time the model instance call the save method.

Also it updates the field `PeriodicTask.date_changed` every time the model instance is saved.

Unfortunetly mongoengine DateTimeField [have no](https://github.com/MongoEngine/mongoengine/issues/1588) auto_now_add/auto_now like django model do. The only way to do this is using [signals](https://docs.mongoengine.org/guide/signals.html) provided by `blinker`

So this PR introduces `blinker` as a new dependence.
